### PR TITLE
Attempt to find a vanity name when composing message

### DIFF
--- a/publish/debug.go
+++ b/publish/debug.go
@@ -11,6 +11,7 @@ type DebugPublisher struct{}
 
 // Publish logs ballot directly to stdout
 func (d *DebugPublisher) Publish(ballot *models.Ballot) error {
-	fmt.Printf("%s voted %s for proposal %s", ballot.PKH, ballot.Ballot, ballot.ProposalHash)
+	status := GetStatusString(ballot)
+	fmt.Printf("%s\n", status)
 	return nil
 }

--- a/publish/msg.go
+++ b/publish/msg.go
@@ -1,0 +1,40 @@
+package publish
+
+import (
+	"fmt"
+	"log"
+	"net"
+
+	"github.com/ecadlabs/tezos-bot/models"
+)
+
+// GetStatusString composes a status string based on available vanity data
+func GetStatusString(ballot *models.Ballot) string {
+
+	templateBasic := `Tezos address %s voted "%s" on #Tezos proposal "%s""`
+	templateVanity := `Tezos baker "%s"/%s voted "%s" on #Tezos proposal "%s"`
+	// TODO(jev) update to query Proposal vanity name for DNS
+	proposalVanityName := "Athens A"
+
+	// tz.tezz.ie is an experimental DNS zone to resolve vanity names from tz
+	// addresses
+	address, err := LookupTZName(ballot.PKH, "tz.tezz.ie")
+
+	if err != nil {
+		log.Printf("No address found for %s, err: %s", ballot.PKH, err)
+		return fmt.Sprintf(templateBasic, ballot.PKH, ballot.Ballot, proposalVanityName)
+	}
+	log.Printf("Address %s found for %s, ", address, ballot.PKH)
+	return fmt.Sprintf(templateVanity, address, ballot.PKH, ballot.Ballot, proposalVanityName)
+
+}
+
+// LookupTZName queries DNS for a txt record corresponding to a TZ address.
+func LookupTZName(address, zone string) (string, error) {
+	query := fmt.Sprintf("%s.%s", address, zone)
+	rrs, err := net.LookupTXT(query)
+	if err != nil {
+		return "", err
+	}
+	return string(rrs[0]), nil
+}

--- a/publish/twitter.go
+++ b/publish/twitter.go
@@ -1,8 +1,6 @@
 package publish
 
 import (
-	"fmt"
-
 	"github.com/dghubble/go-twitter/twitter"
 	"github.com/dghubble/oauth1"
 	"github.com/ecadlabs/tezos-bot/models"
@@ -46,8 +44,7 @@ func NewTwitterPublisher(config TwitterConfig) (*TwitterPublisher, error) {
 
 // Publish a new ballot as a tweet
 func (t *TwitterPublisher) Publish(ballot *models.Ballot) error {
-	status := fmt.Sprintf("Tezos address %s voted \"%s\" on #Tezos proposal \"%s\"", ballot.PKH, ballot.Ballot, "Athens A")
-
+	status := GetStatusString(ballot)
 	_, _, err := t.client.Statuses.Update(status, nil)
 	return err
 }


### PR DESCRIPTION
When we compose the message, we query our experimental DNS zone for a
vanity name. This allows the bot to tweet the vanity name of the Baker.

If you wish to have the bot tweet a vanity name for your address when
you vote, then please send an email to frontdesk@ecadlabs.com