### PR TITLE
Add number of rolls to voting message

### DIFF
--- a/listen/tezos.go
+++ b/listen/tezos.go
@@ -90,11 +90,25 @@ func (t *TezosListener) Start() {
 				}
 			}
 
+			listings, err := t.service.GetBallotListings(ctx, t.config.GetChainID(), hash)
+
+			if err != nil {
+				fmt.Printf("Block: %s skipped because of error: %s\n", hash, err.Error())
+				continue
+			}
+
 			for _, ballotOp := range ballotOps {
+				rolls := int64(0)
+				for _, entry := range listings {
+					if entry.PKH == ballotOp.Source {
+						rolls = entry.Rolls
+					}
+				}
 				ballot := &models.Ballot{
 					PKH:          ballotOp.Source,
 					Ballot:       ballotOp.Ballot,
 					ProposalHash: ballotOp.Proposal,
+					Rolls:        rolls,
 				}
 				t.votesChan <- ballot
 			}

--- a/models/vote.go
+++ b/models/vote.go
@@ -5,4 +5,5 @@ type Ballot struct {
 	PKH          string
 	Ballot       string
 	ProposalHash string
+	Rolls        int64
 }

--- a/publish/msg.go
+++ b/publish/msg.go
@@ -11,10 +11,15 @@ import (
 // GetStatusString composes a status string based on available vanity data
 func GetStatusString(ballot *models.Ballot) string {
 
-	templateBasic := `Tezos address %s voted "%s" on #Tezos proposal "%s"`
-	templateVanity := `Tezos baker "%s"/%s voted "%s" on #Tezos proposal "%s"`
+	templateBasic := `Tezos address %s voted "%s" %son #Tezos proposal "%s"`
+	templateVanity := `Tezos baker "%s"/%s voted "%s" %son #Tezos proposal "%s"`
 	// TODO(jev) update to query Proposal vanity name for DNS
 	proposalVanityName := "Athens A"
+
+	templateRolls := ""
+	if ballot.Rolls != 0 {
+		templateRolls = fmt.Sprintf("with %d rolls ", ballot.Rolls)
+	}
 
 	// tz.tezz.ie is an experimental DNS zone to resolve vanity names from tz
 	// addresses
@@ -22,10 +27,10 @@ func GetStatusString(ballot *models.Ballot) string {
 
 	if err != nil {
 		log.Printf("No address found for %s, err: %s", ballot.PKH, err)
-		return fmt.Sprintf(templateBasic, ballot.PKH, ballot.Ballot, proposalVanityName)
+		return fmt.Sprintf(templateBasic, ballot.PKH, ballot.Ballot, templateRolls, proposalVanityName)
 	}
 	log.Printf("Address %s found for %s, ", address, ballot.PKH)
-	return fmt.Sprintf(templateVanity, address, ballot.PKH, ballot.Ballot, proposalVanityName)
+	return fmt.Sprintf(templateVanity, address, ballot.PKH, ballot.Ballot, templateRolls, proposalVanityName)
 
 }
 


### PR DESCRIPTION
Add the number of rolls to the published message

In case there is an error fetching the rolls for the current block it will skip publishing for that block.

If the number of rolls can't be found for the address which is voting it will publish a message that do contains the `rolls` part

closes #2 